### PR TITLE
MenuBar with File and Help options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ qt_add_executable(appLocalSplits
         Components/Split/splititem.h
         Components/SplitList/splitlistdata.cpp
         Components/SplitList/splitlistdata.h
+        Components/Split/split.cpp
+        Components/Split/split.h
 )
 
 qt_add_qml_module(appLocalSplits
@@ -40,11 +42,17 @@ qt_add_qml_module(appLocalSplits
         Components/SplitList/qmldir
         Components/EditableLabel/qmldir
         Components/SplitFooterButton/qmldir
+        Components/SplitsMenuBar/qmldir
+        Components/AboutPopup/qmldir
     QML_FILES
         Components/SplitRow/SplitRow.qml
         Components/SplitList/SplitList.qml
         Components/EditableLabel/EditableLabel.qml
         Components/SplitFooterButton/SplitFooterButton.qml
+        Components/SplitsMenuBar/SplitsMenuBar.qml
+        Components/SplitsMenuBar/SplitsMenuItem.qml
+        Components/SplitsMenuBar/SplitsMenu.qml
+        Components/AboutPopup/AboutPopup.qml
 )
 
 # Qt for iOS sets MACOSX_BUNDLE_GUI_IDENTIFIER automatically since Qt 6.1.

--- a/Components/AboutPopup/AboutPopup.qml
+++ b/Components/AboutPopup/AboutPopup.qml
@@ -1,0 +1,61 @@
+import QtQuick
+import QtQuick.Effects
+import QtQuick.Layouts
+import QtQuick.Controls
+import "../Fonts"
+
+Window {
+    title: qsTr("About")
+
+    width: 400
+    height: 150
+
+    Pane {
+
+        anchors.fill: parent
+        padding: 4
+
+        ColumnLayout {
+            Label {
+                text: `${Application.displayName} (${Application.version})`
+                color: "#ffffff"
+                font.family: OpenSans.family
+                font.styleName: OpenSans.bold
+                font.pointSize: 16
+            }
+
+            Label {
+                text: "Created by Charles Reverand and Pranav Tripuraneni"
+                color: "#ffffff"
+                font.family: OpenSans.family
+                font.styleName: OpenSans.regular
+                font.pointSize: 10
+            }
+
+            Label {
+                text: "Licenses & Attributions"
+                color: "#ffffff"
+                font.family: OpenSans.family
+                font.styleName: OpenSans.regular
+                font.pointSize: 10
+            }
+
+            Text {
+                text: "<a href='https://www.github.com/taliyos/LocalSplits/releases'>Releases</a>"
+                textFormat: Text.RichText
+                onLinkActivated: Qt.openUrlExternally(link)
+
+                color: "#ffffff"
+                font.family: OpenSans.family
+                font.styleName: OpenSans.regular
+                font.pointSize: 10
+
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.NoButton
+                    cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
+                }
+            }
+        }
+    }
+}

--- a/Components/AboutPopup/qmldir
+++ b/Components/AboutPopup/qmldir
@@ -1,0 +1,1 @@
+module AboutPopup

--- a/Components/EditableLabel/EditableLabel.qml
+++ b/Components/EditableLabel/EditableLabel.qml
@@ -8,6 +8,13 @@ MouseArea {
     property bool isClicked: false
     property string text: "Text"
     property color textColor: "#ffffff"
+    property int pointSize: 10
+    property int wrapMode: Text.NoWrap
+    property int horizontalAlignment: Text.AlignLeft
+    property int verticalAlignment: Text.AlignVCenter
+    property string readFontStyle: OpenSans.bold
+    property string editFontStyle: OpenSans.regular
+
 
     signal editStarted
     signal editConfirmed(editedText: string)
@@ -36,6 +43,11 @@ MouseArea {
         else return label.contentWidth;
     }
 
+    function getChildHeight() {
+        if (isClicked) return edit.contentHeight;
+        else return label.contentHeight;
+    }
+
     onDoubleClicked: {
         startEdit()
     }
@@ -45,15 +57,18 @@ MouseArea {
 
         width: parent.width
         height: parent.height
-        verticalAlignment: Text.AlignVCenter
-        font.pointSize: 10
+        horizontalAlignment: mouseArea.horizontalAlignment
+        verticalAlignment: mouseArea.verticalAlignment
+        font.pointSize: mouseArea.pointSize
         font.family: OpenSans.family
-        font.styleName: OpenSans.bold
+        font.styleName: mouseArea.readFontStyle
 
         color: mouseArea.textColor
         text: parent.text
 
         visible: !parent.isClicked
+
+        wrapMode: mouseArea.wrapMode
     }
 
     TextEdit {
@@ -61,15 +76,18 @@ MouseArea {
 
         width: parent.width
         height: parent.height
-        verticalAlignment: Text.AlignVCenter
-        font.pointSize: 10
+        horizontalAlignment: mouseArea.horizontalAlignment
+        verticalAlignment: mouseArea.verticalAlignment
+        font.pointSize: mouseArea.pointSize
         font.family: OpenSans.family
-        font.styleName: OpenSans.regular
+        font.styleName: mouseArea.editFontStyle
 
         color: mouseArea.textColor
         text: parent.text
 
         visible: parent.isClicked
+        wrapMode: mouseArea.wrapMode
+
 
         onEditingFinished: {
             parent.focus = false

--- a/Components/Split/split.cpp
+++ b/Components/Split/split.cpp
@@ -1,0 +1,122 @@
+#include "split.h"
+
+#include <QDir>
+#include <qurl.h>
+
+#include "Components/SplitLayoutParsing/layoutparser.h"
+#include "Components/SplitList/splitlistdata.h"
+
+Split::Split(QObject *parent) : QObject(parent) {
+    m_layout = new SplitLayout();
+    m_data = new SplitListData();
+}
+
+Split::~Split() {
+    delete m_layout;
+    delete m_data;
+}
+
+SplitLayout* Split::getLayout() const {
+    return m_layout;
+}
+
+SplitListData* Split::getData() const {
+    return m_data;
+}
+
+void Split::openFile(const QString& fileLocation) {
+    delete m_layout;
+
+    m_data->clear();
+
+    const QUrl url(fileLocation);
+    QString filePath;
+    if (url.isLocalFile()) {
+       filePath = QDir::toNativeSeparators(url.toLocalFile());
+    } else {
+        filePath = fileLocation;
+    }
+
+    m_layout = LayoutParser::readLayout(filePath);
+    qDebug() << m_layout->gameName << Qt::endl;
+    if (m_layout == nullptr) return;
+
+    for (int i = 0; i < m_layout->segments.size(); i++) {
+        SplitSegment* segment = m_layout->segments.at(i);
+        m_data->addItem(segment->name, "-");
+    }
+
+    emit gameNameChanged();
+    emit categoryNameChanged();
+    emit runIdChanged();
+    emit platformChanged();
+    emit regionChanged();
+    emit attemptCountChanged();
+}
+
+void Split::newFile() {
+    m_data->clear();
+    delete m_layout;
+    m_layout = new SplitLayout();
+
+    emit gameNameChanged();
+    emit categoryNameChanged();
+    emit runIdChanged();
+    emit platformChanged();
+    emit regionChanged();
+    emit attemptCountChanged();
+}
+
+QString Split::getGameName() const {
+    return m_layout->gameName;
+}
+
+void Split::setGameName(const QString& name) {
+    m_layout->gameName = name;
+    emit gameNameChanged();
+}
+
+QString Split::getCategoryName() const{
+    return m_layout->categoryName;
+}
+
+void Split::setCategoryName(const QString &categoryName) {
+    m_layout->categoryName = categoryName;
+    emit categoryNameChanged();
+}
+
+QString Split::getRunId() const {
+    return m_layout->metadata.runId;
+}
+
+void Split::setRunId(const QString &runId) {
+    m_layout->metadata.runId = runId;
+    emit runIdChanged();
+}
+
+SplitPlatform Split::getPlatform() const {
+    return m_layout->metadata.platform;
+}
+
+void Split::setPlatform(const SplitPlatform &platform) {
+    m_layout->metadata.platform = platform;
+    emit platformChanged();
+}
+
+QString Split::getRegion() const {
+    return m_layout->metadata.region;
+}
+
+void Split::setRegion(const QString &region) {
+    m_layout->metadata.region = region;
+    emit regionChanged();
+}
+
+int Split::getAttemptCount() const {
+    return m_layout->attemptCount;
+}
+
+void Split::setAttemptCount(const int &attemptCount) {
+    m_layout->attemptCount = attemptCount;
+    emit attemptCountChanged();
+}

--- a/Components/Split/split.h
+++ b/Components/Split/split.h
@@ -1,0 +1,67 @@
+
+#ifndef SPLIT_H
+#define SPLIT_H
+#include <QObject>
+
+#include "Components/SplitLayoutParsing/splitplatform.h"
+
+
+class SplitListData;
+struct SplitLayout;
+
+class Split : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(QString gameName READ getGameName WRITE setGameName NOTIFY gameNameChanged)
+    Q_PROPERTY(QString categoryName READ getCategoryName WRITE setCategoryName NOTIFY categoryNameChanged)
+    Q_PROPERTY(QString runId READ getRunId WRITE setRunId NOTIFY runIdChanged)
+    Q_PROPERTY(SplitPlatform platform READ getPlatform WRITE setPlatform NOTIFY platformChanged)
+    Q_PROPERTY(QString region READ getRegion WRITE setRegion NOTIFY regionChanged)
+    Q_PROPERTY(int attemptCount READ getAttemptCount WRITE setAttemptCount NOTIFY attemptCountChanged)
+
+public:
+    explicit Split(QObject* parent = nullptr);
+    ~Split() override;
+
+    SplitLayout* getLayout() const;
+    SplitListData* getData() const;
+
+    QString getGameName() const;
+    void setGameName(const QString& gameName);
+
+    QString getCategoryName() const;
+    void setCategoryName(const QString& categoryName);
+
+    QString getRunId() const;
+    void setRunId(const QString& runId);
+
+    SplitPlatform getPlatform() const;
+    void setPlatform(const SplitPlatform& platform);
+
+    QString getRegion() const;
+    void setRegion(const QString& region);
+
+    int getAttemptCount() const;
+    void setAttemptCount(const int& attemptCount);
+
+signals:
+    void layoutChanged();
+    void gameNameChanged();
+    void categoryNameChanged();
+    void runIdChanged();
+    void platformChanged();
+    void regionChanged();
+    void attemptCountChanged();
+
+
+public slots:
+    void openFile(const QString& fileLocation);
+    void newFile();
+
+private:
+    SplitLayout* m_layout;
+    SplitListData* m_data;
+};
+
+
+
+#endif //SPLIT_H

--- a/Components/Split/splitmodel.cpp
+++ b/Components/Split/splitmodel.cpp
@@ -42,6 +42,12 @@ void SplitModel::setSplits(SplitListData* splits) {
         connect(m_splits, &SplitListData::postItemRemoved, this, [=]() {
             endRemoveRows();
         });
+        connect(m_splits, &SplitListData::preClear, this, [=] {
+            beginResetModel();
+        });
+        connect(m_splits, &SplitListData::postClear, this, [=] {
+            endResetModel();
+        });
     }
     endResetModel();
 }

--- a/Components/SplitLayoutParsing/splitlayout.h
+++ b/Components/SplitLayoutParsing/splitlayout.h
@@ -8,12 +8,14 @@
 #include "Components/SplitLayoutParsing/splitsegment.h"
 
 struct SplitLayout {
+    Q_GADGET
+public:
     QString gameIcon;
-    QString gameName;
-    QString categoryName;
+    QString gameName = "Game Name";
+    QString categoryName = "Category Name";
     SplitMetadata metadata;
     QString offset;
-    int attemptCount;
+    int attemptCount = 0;
     QList<SplitAttempt> attemptHistory;
     QList<SplitSegment*> segments;
 };

--- a/Components/SplitLayoutParsing/splitmetadata.h
+++ b/Components/SplitLayoutParsing/splitmetadata.h
@@ -5,9 +5,11 @@
 #include "Components/SplitLayoutParsing/splitplatform.h"
 
 struct SplitMetadata {
-    QString runId;
+    Q_GADGET
+public:
+    QString runId = "";
     SplitPlatform platform;
-    QString region;
+    QString region = "US";
 };
 
 #endif // SPLITMETADATA_H

--- a/Components/SplitLayoutParsing/splitplatform.h
+++ b/Components/SplitLayoutParsing/splitplatform.h
@@ -4,8 +4,10 @@
 #include <QString>
 
 struct SplitPlatform {
-    QString platform;
-    QString usesEmulator;
+    Q_GADGET
+public:
+    QString platform = "GCN";
+    QString usesEmulator = "Y";
 };
 
 #endif // SPLITPLATFORM_H

--- a/Components/SplitList/splitlistdata.cpp
+++ b/Components/SplitList/splitlistdata.cpp
@@ -51,3 +51,14 @@ void SplitListData::removeItem(int index) {
     m_items.removeAt(index);
     emit postItemRemoved();
 }
+
+void SplitListData::clear() {
+    if (m_items.size() == 0)  return;
+
+    emit preClear();
+    for (int i = 0; i < m_items.size(); i++) {
+        delete m_items[i];
+    }
+    m_items.clear();
+    emit postClear();
+}

--- a/Components/SplitList/splitlistdata.h
+++ b/Components/SplitList/splitlistdata.h
@@ -23,12 +23,15 @@ signals:
     void preItemRemoved(int index);
     void postItemRemoved();
 
+    void preClear();
+    void postClear();
+
 public slots:
-    //
     void addItem();
     void addItem(const QString& name, const QString& time);
     void addItem(const QString& name, const QString& time, const qsizetype& index);
     void removeItem(int index);
+    void clear();
 
 private:
     QVector<SplitItem*> m_items;

--- a/Components/SplitsMenuBar/SplitsMenu.qml
+++ b/Components/SplitsMenuBar/SplitsMenu.qml
@@ -1,0 +1,14 @@
+import QtQuick
+import QtQuick.Effects
+import QtQuick.Layouts
+import QtQuick.Controls
+import QtQuick.Controls.Basic
+
+Menu {
+    background: Rectangle {
+        implicitWidth: 100
+        color: "#1e1e1e"
+        border.color: "#3c3c3c"
+        radius: 2
+    }
+}

--- a/Components/SplitsMenuBar/SplitsMenuBar.qml
+++ b/Components/SplitsMenuBar/SplitsMenuBar.qml
@@ -1,0 +1,93 @@
+import QtQuick
+import QtQuick.Effects
+import QtQuick.Layouts
+import QtQuick.Controls
+import QtQuick.Controls.Basic
+import "../AboutPopup"
+
+MenuBar {
+    id: menuBar
+    height: 20
+
+    //visible: false
+
+    signal newFile
+    signal open
+    signal save
+    signal saveAs
+
+    SplitsMenu {
+        title: qsTr("File")
+        SplitsMenuItem {
+            text: qsTr("&New")
+            onTriggered: { newFile() }
+        }
+        SplitsMenuItem {
+            text: qsTr("&Open")
+            onTriggered: { open() }
+        }
+        SplitsMenuItem {
+            text: qsTr("&Save")
+            onTriggered: { save() }
+        }
+        SplitsMenuItem {
+            text: qsTr("Save &As")
+            onTriggered: { saveAs() }
+        }
+        MenuSeparator { }
+        SplitsMenuItem { text: qsTr("&Preferences") }
+        MenuSeparator { }
+        SplitsMenuItem {
+            text: qsTr("&Quit")
+            onTriggered: {
+                Qt.quit()
+            }
+        }
+    }
+    SplitsMenu {
+        title: qsTr("Help")
+        SplitsMenuItem {
+            text: qsTr("&About")
+            onTriggered: {
+                let component = Qt.createComponent("../AboutPopup/AboutPopup.qml")
+                let window = component.createObject()
+                window.show()
+            }
+        }
+    }
+
+    delegate: MenuBarItem {
+        id: menuBarItem
+        height: 20
+
+        contentItem: Label {
+            text: menuBarItem.text
+            font: menuBarItem.font
+            opacity: enabled ? 1.0 : 0.3
+            color: "#ffffff"
+            horizontalAlignment: Text.AlignLeft
+            verticalAlignment: Text.AlignVCenter
+            elide: Text.ElideRight
+        }
+
+        background: Rectangle {
+            implicitWidth: 40
+            implicitHeight: 20
+            opacity: enabled ? 1 : 0.3
+            color: menuBarItem.highlighted ? "#3d3d3d" : "#00000000"
+        }
+    }
+
+    background: Rectangle {
+        implicitWidth: 40
+        implicitHeight: 20
+        color: "#1e1e1e"
+
+        Rectangle {
+            color: "#2b2b2b"
+            width: parent.width
+            height: 1
+            anchors.bottom: parent.bottom
+        }
+    }
+}

--- a/Components/SplitsMenuBar/SplitsMenuItem.qml
+++ b/Components/SplitsMenuBar/SplitsMenuItem.qml
@@ -1,0 +1,9 @@
+import QtQuick
+import QtQuick.Effects
+import QtQuick.Layouts
+import QtQuick.Controls
+import QtQuick.Controls.Basic
+
+MenuItem {
+    height: 25
+}

--- a/Components/SplitsMenuBar/qmldir
+++ b/Components/SplitsMenuBar/qmldir
@@ -1,0 +1,1 @@
+module SplitsMenuBar

--- a/Main.qml
+++ b/Main.qml
@@ -3,9 +3,12 @@ import QtQuick.Effects
 import QtQuick.Layouts
 import QtQuick.Controls
 import QtQuick.Controls.Basic
+import QtQuick.Dialogs
 import "Components/Fonts"
 import "Components/SplitList"
 import "Components/SplitRow"
+import "Components/EditableLabel"
+import com.localsplits
 
 ApplicationWindow {
     id: window
@@ -14,8 +17,33 @@ ApplicationWindow {
     visible: true
     title: qsTr("LocalSplits")
 
+    menuBar: SplitsMenuBar {
+        onNewFile: {
+            split.newFile()
+        }
+
+        onOpen: {
+            openFileDialog.open()
+        }
+    }
+
+    FileDialog {
+        id: openFileDialog
+
+        acceptLabel: "Open Splits"
+        fileMode: FileDialog.OpenFile
+        nameFilters: ["LocalSplits (*.localsplits)", "LiveSplit (*.lss)"]
+
+        onAccepted: {
+            console.log("file opened")
+            //console.log(split.getName())
+            split.openFile(selectedFile)
+            split.name = "Test123"
+        }
+    }
+
     Pane {
-        id: _main
+        id: main
         anchors.fill: parent
         padding: 4
 
@@ -24,59 +52,79 @@ ApplicationWindow {
             height: parent.height
 
             ColumnLayout {
-                id: _title
+                id: title
                 width: parent.width
                 spacing: 2
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 Layout.fillWidth: true
                 Layout.fillHeight: true
 
-                Label {
-                    id: _titleText
-                    text: gameName
-
-                    horizontalAlignment: Text.AlignHCenter
-                    verticalAlignment: Text.AlignVCenter
-                    wrapMode: Text.WordWrap
+                EditableLabel {
+                    id: titleText
+                    text: split.gameName
                     Layout.alignment: Qt.AlignHCenter
                     Layout.fillWidth: true
+                    Layout.minimumHeight: getChildHeight()
 
-                    color: "#ffffff"
-                    font.family: OpenSans.family
-                    font.styleName: OpenSans.bold
-                    font.pointSize: 12
+                    pointSize: 12
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+
+                    onEditConfirmed: editedText => {
+                        if (split.gameName === editedText) return
+                        console.log("Game name edit: " + split.gameName + " -> " + editedText)
+                        split.gameName = editedText
+                    }
                 }
 
-                Item {
+                RowLayout {
                     Layout.fillWidth: true
-                    Layout.minimumHeight: childrenRect.height
-                    Label {
-                        id: _runCategory
-                        text: qsTr("Any%")
-                        font.pixelSize: 10
+                    //Layout.minimumHeight: childrenRect.height
+                    height: runCategory.height
+
+                    EditableLabel {
+                        id: runCategory
+                        text: split.categoryName
+                        Layout.alignment: Qt.AlignHCenter
+                        Layout.fillWidth: true
+                        Layout.minimumHeight: getChildHeight()
+
+                        pointSize: 9
+                        wrapMode: Text.WordWrap
                         horizontalAlignment: Text.AlignHCenter
                         verticalAlignment: Text.AlignVCenter
-                        wrapMode: Text.NoWrap
-
-                        color: "#ffffff"
-                        font.family: OpenSans.family
-                        font.styleName: OpenSans.bold
 
                         anchors.centerIn: parent
+
+                        onEditConfirmed: editedText => {
+                            if (split.categoryName === editedText) return
+                            console.log("Category name edit: " + split.gameName + " -> " + editedText)
+                            split.categoryName = editedText
+                        }
                     }
 
-                    Label {
-                        id: _attemptCounter
-                        text: qsTr("0")
-                        font.pixelSize: 12
-                        font.bold: false
-                        wrapMode: Text.NoWrap
+                    EditableLabel {
+                        id: attemptCount
+                        text: split.attemptCount
+                        Layout.alignment: Qt.AlignHCenter
+                        Layout.minimumWidth: getChildWidth()
+                        Layout.minimumHeight: getChildHeight()
 
-                        color: "#ffffff"
-                        font.family: OpenSans.family
-                        font.styleName: OpenSans.italic
+                        pointSize: 9
+                        wrapMode: Text.NoWrap
+                        horizontalAlignment: Text.AlignRight
+                        verticalAlignment: Text.AlignVCenter
 
                         anchors.right: parent.right
+                        readFontStyle: OpenSans.italic
+                        debug: true
+
+                        onEditConfirmed: editedText => {
+                            if (split.attemptCount === editedText) return
+                            console.log("Category name edit: " + split.attemptCount + " -> " + editedText)
+                            split.attemptCount = parseInt(editedText)
+                        }
                     }
                 }
             }
@@ -125,6 +173,11 @@ ApplicationWindow {
         background: Rectangle {
             color: "#1e1e1e"
         }
+
+    }
+
+    onClosing: {
+        Qt.quit()
     }
 
 }

--- a/main.cpp
+++ b/main.cpp
@@ -5,30 +5,28 @@
 #include <QQmlEngine>
 #include <QQuickView>
 
+#include "Components/Split/split.h"
 #include "Components/Split/splitmodel.h"
 #include "Components/SplitLayoutParsing/layoutparser.h"
 #include "Components/SplitList/splitlistdata.h"
 
 int main(int argc, char *argv[])
 {
+    QCoreApplication::setApplicationName("LocalSplits");
+    QCoreApplication::setApplicationVersion("0.1");
+
     QGuiApplication app(argc, argv);
 
     qmlRegisterType<SplitModel>("com.localsplits", 1, 0, "SplitModel");
     qmlRegisterUncreatableType<SplitListData>("com.localsplits", 1, 0, "SplitListData", QStringLiteral("SplitListData should not be created in QML"));
 
-    SplitLayout* splitLayout = LayoutParser::readLayout("tests\\testLayout.lss");
-    if (splitLayout == nullptr) return -1;
-
-    SplitListData* splitList = new SplitListData();
-
-    for (int i = 0; i < splitLayout->segments.size(); i++) {
-        SplitSegment* segment = splitLayout->segments.at(i);
-        splitList->addItem(segment->name, "-");
-    }
+    Split* split = new Split();
+    split->openFile("tests\\testLayout.lss");
 
     QQmlApplicationEngine engine;
-    engine.rootContext()->setContextProperty(QStringLiteral("gameName"), QVariant(splitLayout->gameName));
-    engine.rootContext()->setContextProperty(QStringLiteral("splitList"), splitList);
+    engine.rootContext()->setContextProperty(QStringLiteral("split"), split);
+    engine.rootContext()->setContextProperty(QStringLiteral("gameName"), QVariant(split->getLayout()->gameName));
+    engine.rootContext()->setContextProperty(QStringLiteral("splitList"), split->getData());
 
     QObject::connect(
         &engine,
@@ -37,10 +35,6 @@ int main(int argc, char *argv[])
         []() { QCoreApplication::exit(-1); },
         Qt::QueuedConnection);
     engine.loadFromModule("LocalSplits", "Main");
-
-    delete splitLayout;
-
-    //QObject::connect(&engine, &QQmlApplicationEngine::quit, &app, [] {onAppExit();}, Qt::QueuedConnection);
 
     return app.exec();
 }


### PR DESCRIPTION
This PR adds a menubar with options for file and help.
In conjunction with this the split file loading and processing has been moved to a separate **Split** class that is exposed in QML.
Game name, category name, and attempt count have been migrated to utilize the split data and are now editable from the UI.

https://github.com/user-attachments/assets/8478a5e7-13a7-481d-b75c-d3817149e7af

